### PR TITLE
Clarify Streamlit secrets instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ Secrets are **not** stored in the repository. Set the following environment vari
 - `STRIPE_SUCCESS_URL`
 - `STRIPE_CANCEL_URL`
 
-You can copy `.streamlit/secrets.example.toml` and fill in your values when developing locally.
+Copy `.streamlit/secrets.example.toml` to `.streamlit/secrets.toml` and fill in your values when developing locally. Streamlit reads `secrets.toml` automatically when it is present. Make sure the `[supabase] anon_key` value is populated in this file or provided via the `SUPABASE_ANON_KEY` environment variable before running the app.
 
 Install dependencies with `pip install -r requirements.txt` and start the app using `streamlit run app.py`.


### PR DESCRIPTION
## Summary
- mention copying `secrets.example.toml` to `secrets.toml`
- note that Streamlit automatically loads the file
- emphasize the `[supabase] anon_key` requirement

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6841f7b204a8832bab4bb97e16f7996b